### PR TITLE
Add code to support a background queue

### DIFF
--- a/test/tooling_job_test.rb
+++ b/test/tooling_job_test.rb
@@ -31,6 +31,19 @@ module Exercism
 
       assert redis.get("submission:#{submission_uuid}:#{type}")
       assert redis.get("job:#{job.id}")
+      assert_equal job.id, redis.lpop(ToolingJob.key_for_queued)
+    end
+
+    def test_queues_job_in_background
+      redis = Exercism.redis_tooling_client
+      submission_uuid = SecureRandom.uuid
+      type = :test_runner
+
+      job = ToolingJob.create!(type, submission_uuid, :ruby, "two-fer", run_in_background: true)
+
+      assert redis.get("submission:#{submission_uuid}:#{type}")
+      assert redis.get("job:#{job.id}")
+      assert_equal job.id, redis.lpop(ToolingJob.key_for_queued_in_background)
     end
 
     def test_cancels_test_runner_job


### PR DESCRIPTION
Supports https://github.com/exercism/tooling-orchestrator/pull/33 and https://github.com/exercism/website/pull/2198/files#diff-564edea0a2100e777760ef9570615d038ad994094b3050c17b44e9ebb7db175dR22