### PR TITLE
Fix website assets host for CI

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -25,7 +25,7 @@ aws_tooling_jobs_bucket: exercism-v3-tooling-jobs
 
 # Hosts
 website_icons_host: https://exercism-v3-icons.s3.eu-west-2.amazonaws.com
-website_assets_host:
+website_assets_host: ""
 
 # Sidekiq Config
 sidekiq_redis_url: redis://127.0.0.1:6379/2


### PR DESCRIPTION
This fixes the system tests in the website CI, which is needed to allow us to ﻿upgrade the config version for the website.
The bug was introduced when we changed the `website_assets_host` in a (successful) attempt to fix the image URLs.
It did break the system tests though, see https://github.com/exercism/website/pull/2498/commits/a235e2c2a3da4f78770721dd72773cb4ff91961b
This PR changes the assets host to an empty string, not `null`, which fixes the issue as can be seen at https://github.com/exercism/website/pull/2498/commits/f70cf188ffd1abbb7dd1cd00bfb52c71d8ee761f
