### PR TITLE
Use `assets.exercism.org` subdomain

### DIFF
--- a/settings/ci.yml
+++ b/settings/ci.yml
@@ -28,7 +28,7 @@ aws_submissions_bucket: exercism-v3-submissions
 aws_tooling_jobs_bucket: exercism-v3-tooling-jobs
 
 # Hosts
-website_icons_host: https://exercism-v3-icons.s3.eu-west-2.amazonaws.com
+website_icons_host: https://assets.exercism.org
 website_assets_host: ""
 
 # Sidekiq Config

--- a/settings/local.yml
+++ b/settings/local.yml
@@ -29,7 +29,7 @@ aws_submissions_bucket: exercism-v3-submissions
 aws_tooling_jobs_bucket: exercism-v3-tooling-jobs
 
 # Hosts
-website_icons_host: https://exercism-v3-icons.s3.eu-west-2.amazonaws.com
+website_icons_host: https://assets.exercism.org
 website_assets_host:
 
 # Sidekiq Config


### PR DESCRIPTION
Hi there. We're moving various parts of our image hosting behind a CDN, and so various links to images are changing. This PR updates the urls we automatically found in this repository. If you come across any more links pointing to `exercism-v3-icons.s3.eu-west-2.amazonaws.com` or `dg8krxphbh767.cloudfront.net`, please change those to `assets.exercism.org` too. Thanks!