### PR TITLE
Reuse Redis clients rather than building one per call

### DIFF
--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -17,16 +17,42 @@ module Exercism
   def self.redis_git_cache_client = redis_client(config.git_cache_redis_url)
   def self.redis_cache_client = redis_client(config.cache_redis_url)
 
+  # Clients are cached per-url because building one is expensive. In production
+  # this is a Redis::Cluster, which does full topology discovery (CLUSTER NODES,
+  # then a connection to every node in the cluster) the first time it runs a
+  # command - measured at ~38ms against production. Callers that talk to Redis
+  # in a loop were paying that on every single call, and discarding all those
+  # connections afterwards.
+  #
+  # redis-rb 5 runs every command through a Monitor, so sharing one instance
+  # across threads is safe. The cache is invalidated on fork so that Puma and
+  # Sidekiq children build their own clients rather than using sockets they
+  # inherited from the parent.
   def self.redis_client(url)
     require 'redis'
     require 'redis-clustering'
 
+    @redis_clients_mutex.synchronize do
+      if @redis_clients_pid != Process.pid
+        @redis_clients = {}
+        @redis_clients_pid = Process.pid
+      end
+
+      @redis_clients[url] ||= new_redis_client(url)
+    end
+  end
+
+  def self.new_redis_client(url)
     if Exercism.env.development? || Exercism.env.test?
       Redis.new(url:)
     else
       Redis::Cluster.new(nodes: [url])
     end
   end
+
+  @redis_clients = {}
+  @redis_clients_pid = Process.pid
+  @redis_clients_mutex = Mutex.new
 
   def self.dynamodb_client
     Aws::DynamoDB::Client.new(ExercismConfig::GenerateAwsSettings.())

--- a/lib/exercism_config/version.rb
+++ b/lib/exercism_config/version.rb
@@ -1,3 +1,3 @@
 module ExercismConfig
-  VERSION = '0.131.0'.freeze
+  VERSION = '0.132.0'.freeze
 end

--- a/test/exercism_test.rb
+++ b/test/exercism_test.rb
@@ -5,6 +5,27 @@ class ExercismTest < Minitest::Test
     assert Exercism.env
   end
 
+  def test_redis_clients_are_reused
+    Exercism.stubs(env: ExercismConfig::Environment.new(:test))
+
+    assert_same Exercism.redis_cache_client, Exercism.redis_cache_client
+  end
+
+  def test_redis_clients_are_per_url
+    Exercism.stubs(env: ExercismConfig::Environment.new(:test))
+
+    refute_same Exercism.redis_client("redis://localhost:6379/1"), Exercism.redis_client("redis://localhost:6379/2")
+  end
+
+  def test_redis_clients_are_rebuilt_after_fork
+    Exercism.stubs(env: ExercismConfig::Environment.new(:test))
+
+    client = Exercism.redis_cache_client
+    Process.stubs(pid: Process.pid + 1)
+
+    refute_same client, Exercism.redis_cache_client
+  end
+
   def test_cloudfront_client
     cloudfront_client = Exercism.cloudfront_client
     assert_equal "eu-west-2", cloudfront_client.config.region


### PR DESCRIPTION
## Problem

`redis_client` builds a **new** client on every call:

```ruby
def self.redis_tooling_client = redis_client(config.tooling_redis_url)
def self.redis_git_cache_client = redis_client(config.git_cache_redis_url)
def self.redis_cache_client = redis_client(config.cache_redis_url)

def self.redis_client(url)
  ...
  Redis::Cluster.new(nodes: [url])
end
```

In production that is a `Redis::Cluster`, which builds its `Router` lazily on first command — meaning full topology discovery: connect to the seed node, `CLUSTER NODES`, then open a connection to every node in the cluster. Every instance pays it, and we throw all those connections away immediately afterwards.

Measured on production — cold (new client each time) vs warm (one reused client):

```
cold: 45.0ms   warm: 34.9ms   <- first call builds the router
cold: 37.1ms   warm:  1.6ms
cold: 43.6ms   warm:  1.7ms
cold: 35.0ms   warm:  1.5ms
cold: 32.0ms   warm:  1.5ms
```

~24× per call, and any caller in a loop multiplies it.

## Impact found so far

The website's `User::ReputationToken::CalculateContextualData` calls `redis_cache_client` once per user per cache key. Rendering the 20-strong contributors list on `/community` and `/contributing/contributors` therefore built **40 cluster clients per page render**.

That showed up as `CommunityController#show` sitting at 2.7s p50 / 5.0s p95 in Skylight, with ~4s of unexplained self time in the template — unexplained because Skylight has no Redis probe, so none of it was attributable. The production query log made it obvious once we knew where to look: a 1.5s gap containing zero queries.

Memoizing takes `AssembleContributors` from ~1550ms to ~100ms on production.

`Metrics` has the same shape, building 2-3 clients per call.

## The change

Clients are cached per-url.

- **Thread safety**: redis-rb 5 runs every command through a `Monitor` ([`redis.rb:146`](https://github.com/redis/redis-rb/blob/master/lib/redis.rb)), so sharing one instance across Puma threads is safe.
- **Fork safety**: the cache is keyed on the pid, so a forked Puma or Sidekiq child builds its own client rather than using sockets inherited from the parent.

Verified: same url reused, different urls distinct, rebuilt after a pid change, and 20 concurrent threads get a single instance.

Version bumped to 0.132.0.

## Note

The test suite doesn't load on Ruby 3.4 on `main` — `bigdecimal` left the default gems in 3.4 and isn't declared, so `require 'aws-sdk-dynamodb'` blows up before any test runs. I've left that alone rather than widen this PR, but it needs fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PThVRWeFZ2KHR6cwVFinX3